### PR TITLE
Ignore private packages from snapshots

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -124,8 +124,8 @@ try {
     const {packages} = await getPackages(process.cwd());
     const snapshots = [];
     packages.forEach(({packageJson}) => {
-      const {name, version} = packageJson;
-      if (name && version && version.includes(versionPrefix))
+      const {name, version, private: isPrivate} = packageJson;
+      if (name && version && !isPrivate && version.includes(versionPrefix))
         snapshots.push(`${name}@${version}`);
     });
     const snapshotTimestamp = snapshots[0].split('-').at(-1);


### PR DESCRIPTION
All packages are currently being published. We shouldn't publish packages that have `"private": "true"` set.

The current setup is publishing `polaris.shopify.com` as a snapshot:

<img width="875" alt="Screenshot 2024-04-11 at 7 47 32 AM" src="https://github.com/Shopify/snapit/assets/11774595/ba1cb1a4-d52b-4efe-b0b4-95ca7549960c">

Alternatively, we could add an ignore list. Though, I think changeset only published public packages by default.