### PR TITLE
Check for snapshots before getting timestamp

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -128,11 +128,12 @@ try {
       if (name && version && !isPrivate && version.includes(versionPrefix))
         snapshots.push(`${name}@${version}`);
     });
-    const snapshotTimestamp = snapshots[0].split('-').at(-1);
 
     if (!snapshots.length) {
       throw new Error('Changeset publish did not create new tags.');
     }
+
+    const snapshotTimestamp = snapshots[0].split('-').at(-1);
 
     if (branch) {
       // We all think this is weird


### PR DESCRIPTION
See [action failure here](https://github.com/Shopify/snapit-cloudsmith-docs/actions/runs/8648489509/job/23712407318#step:4:29).